### PR TITLE
make ex_doc only-dev dep

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Statistics.Mixfile do
   end
 
   defp deps do
-     [ { :ex_doc, github: "elixir-lang/ex_doc"} ]
+     [ { :ex_doc, github: "elixir-lang/ex_doc", only: :dev } ]
   end
 
   defp description do


### PR DESCRIPTION
Hello!
Your project looks neat :)

Now from my experience this little change is going to make life easier.

Generating a documentation is usually task you do on your dev machine. It's not necessary to carry this package as a prod subdep when someone uses your package as a dep.

Also, a single git dep can screw deps resolution - again, this is usually not hurting when you're inside _this_ project, but starts to be annoying when people grab your code from Hex as a dep. Not to mention they can have their own preferred version of ex_doc in their project's dev toolchain.
