### PR TITLE
Allow Elixir versions higher than 1.1.X

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Statistics.Mixfile do
   def project do
     [ app: :statistics,
       version: File.read!("VERSION") |> String.strip,
-      elixir: "~> 1.1.0",
+      elixir: ">= 1.1.0",
       description: description,
       package: package,
       deps: deps ]


### PR DESCRIPTION
`elixir: "~> 1.1.0"` in `mix.exs` causes build warning when using Elixir 1.2. However, the library seems to work perfectly fine with those versions (I tested with 1.2.4): tests are passing and usage seems to be ok too. I also reviewed changelogs and I haven't found any breaking changes which would render the lib unusable. I don't know about 1.3.0, however. Let me know what you think.