### PR TITLE
Add the case to handle single element list for percentile

### DIFF
--- a/lib/statistics.ex
+++ b/lib/statistics.ex
@@ -178,6 +178,7 @@ defmodule Statistics do
   """
   @spec percentile(list,number) :: number
   def percentile([], _), do: nil
+  def percentile([x], _), do: x
   def percentile(list, 0), do: min(list)
   def percentile(list, 100), do: max(list)
   def percentile(list, n) when is_list(list) and is_number(n) do

--- a/lib/statistics.ex
+++ b/lib/statistics.ex
@@ -170,6 +170,8 @@ defmodule Statistics do
 
       iex> Statistics.percentile([], 50)
       nil
+      iex> Statistics.percentile([1], 50)
+      1
       iex> Statistics.percentile([1,2,3,4,5,6,7,8,9],80)
       7.4
       iex> Statistics.percentile([1,2,3,4,5,6,7,8,9],100)

--- a/test/descriptive_test.exs
+++ b/test/descriptive_test.exs
@@ -10,6 +10,7 @@ defmodule DescriptiveTest do
   @d @a ++ [8,7,6,5,4,3]
   @e [1,2,3,2,1]
   @f Enum.to_list(1..6)
+  @g [1]
 
   @x [1,2,3,4,12,4,2,4,6,3,5,6,7,4,7,8,2,5]
   @y [1,3,5,6,5,2,7,4,6,8,2,3,9,5,2,8,9,4]
@@ -62,6 +63,7 @@ defmodule DescriptiveTest do
     assert Statistics.percentile(@a, 20) == 2.6
     assert Statistics.percentile(@a, 80) == 7.4
     assert Statistics.percentile(@a, 100) == 9
+    assert Statistics.percentile(@g, 50) == 1
   end
 
   test "get range" do


### PR DESCRIPTION
A single element list should return that element when calculating percentile. At the moment, it fails silently with an error.