### PR TITLE
Fixes the exponential distribution's rand function

### DIFF
--- a/lib/statistics/distributions/exponential.ex
+++ b/lib/statistics/distributions/exponential.ex
@@ -98,9 +98,9 @@ defmodule Statistics.Distributions.Exponential do
   end
 
   @doc """
-  Draw a random number from the distribution with specified lambda
+  Draw a random variate from the distribution with specified lambda
 
-  Uses the [rejection sampling method](https://en.wikipedia.org/wiki/Rejection_sampling)
+  Uses the closed-form inverse CDF (PPF) evaluated with uniform number between 0.0 and 1.0
 
   ## Examples
 
@@ -115,13 +115,6 @@ defmodule Statistics.Distributions.Exponential do
   end
 
   def rand(lambda) do
-    x = Math.rand() * lambda * 100
-
-    if pdf(lambda).(x) > Math.rand() do
-      x
-    else
-      # keep trying
-      rand(lambda)
-    end
+    ppf(lambda).(Math.rand())
   end
 end

--- a/test/exponential_distribution_test.exs
+++ b/test/exponential_distribution_test.exs
@@ -34,4 +34,14 @@ defmodule ExponentialDistributionTest do
     assert Exponential.ppf(1).(0.5) == 0.6931471805599453
     assert Exponential.ppf(4).(0.9) == 0.57564627324851148
   end
+
+  test "generating many random variates gives roughly the expected mean" do
+    n = 100_000
+    lambda = 0.002
+    expected_mean = 1/lambda
+    sample_mean = Enum.sum(Enum.map(1..n, fn _ -> Exponential.rand(lambda) end))/n
+
+    assert 0.95 * expected_mean <= sample_mean
+    assert sample_mean <= 1.05 * expected_mean
+  end
 end


### PR DESCRIPTION
- The existing version does not seem to generate sensible random variates.
  For example, for a lambda of 0.002 we expect a mean value of 500. The
  existing function averages around 0.1 for the given lambda value.
- The existing version attempts to use rejection sampling. We don't need
  to do rejection sampling for the exponential distribution because we have
  a closed form for the inverse CDF (PPF). We simply generate a uniform
  number between 0.0 and 1.0 and pass that to the PPF and we will get
  properly distributed random variates.