### PR TITLE
Optimize Statistics.median/1

### DIFF
--- a/lib/statistics.ex
+++ b/lib/statistics.ex
@@ -52,26 +52,23 @@ defmodule Statistics do
   """
   @spec median(list) :: number
   def median([]), do: nil
+  def median([m]), do: m
 
   def median(list) when is_list(list) do
-    midpoint =
-      (length(list) / 2)
-      |> Float.floor()
-      |> round
+    list = Enum.sort(list)
+    len = length(list)
 
-    {l1, l2} =
-      Enum.sort(list)
-      |> Enum.split(midpoint)
-
-    case length(l2) > length(l1) do
-      true ->
-        [med | _] = l2
-        med
-
-      false ->
-        [m1 | _] = l2
-        [m2 | _] = Enum.reverse(l1)
+    case rem(len, 2) do
+      0 ->
+        # even number of elements, take mean of "left mid" and "right mid"
+        left_mid_index = div(len, 2) - 1
+        [m1, m2] = Enum.slice(list, left_mid_index, 2)
         mean([m1, m2])
+
+      1 ->
+        # odd number of elements, take the middle one.
+        mid_index = div(len, 2)
+        Enum.at(list, mid_index)
     end
   end
 

--- a/test/descriptive_test.exs
+++ b/test/descriptive_test.exs
@@ -32,8 +32,10 @@ defmodule DescriptiveTest do
 
   test "calculate median" do
     assert Statistics.median(@null) == nil
+    assert Statistics.median(@g) == 1
     assert Statistics.median(@a) == 5
     assert Statistics.median(@a -- [9]) == 4.5
+    assert Statistics.median(@e) == 2
   end
 
   test "get maximum" do


### PR DESCRIPTION
This improves the current implementation in a few ways:

* Fewer Kernel.length/1 calls. This function takes time proportional to the length of the list, so is slower for larger lists and should be avoided if possible.
* Fewer allocations. There's no need to create large, new lists to calculate the median.
* Removing expensive additional Enum.sort/1 call.

A test is added for the new edge case of a list with one element, and for an input list that isn't already sorted.

You can test the performance in `iex -S mix` with:

```
list = for _ <- 0..1000, do: :rand.uniform(100)
:timer.tc(fn ->
  Enum.each(0..100, fn _ -> Statistics.median(list) end)
end)
```

which will generate a list of 1,000 random numbers from 0 to 100, and then call `Statistics.median` on it 100 times. The value it reports is in microseconds.

~On my machine the current master took 12,100 µs while my branch took 2,800 µs.~

Edit: Hm, I can't reproduce these results. In my testing now they take roughly the same time (with maybe just a small edge towards my branch). In that vein, I'm closing the PR. It's not the performance win I thought it was at first.