### PR TITLE
move some run-time operations to compile-time through pattern matching

### DIFF
--- a/lib/statistics.ex
+++ b/lib/statistics.ex
@@ -126,10 +126,7 @@ defmodule Statistics do
   """
   @spec min(list) :: number
   def min([]), do: nil
-
-  def min(list) do
-    Enum.min(list)
-  end
+  def min(list), do: Enum.min(list)
 
   @doc """
   Get the maximum value from a list
@@ -143,10 +140,7 @@ defmodule Statistics do
   """
   @spec max(list) :: number
   def max([]), do: nil
-
-  def max(list) do
-    Enum.max(list)
-  end
+  def max(list), do: Enum.max(list)
 
   @doc """
   Get the quartile cutoff value from a list

--- a/lib/statistics/distributions/beta.ex
+++ b/lib/statistics/distributions/beta.ex
@@ -19,14 +19,9 @@ defmodule Statistics.Distributions.Beta do
   def pdf(a, b) do
     bab = Functions.beta(a, b)
 
-    fn x ->
-      cond do
-        x <= 0.0 ->
-          0.0
-
-        true ->
-          Math.pow(x, a - 1) * Math.pow(1 - x, b - 1) / bab
-      end
+    fn
+      x when x <= 0.0 -> 0.0
+      x -> Math.pow(x, a - 1) * Math.pow(1 - x, b - 1) / bab
     end
   end
 
@@ -37,7 +32,7 @@ defmodule Statistics.Distributions.Beta do
 
       iex> Statistics.Distributions.Beta.cdf(1,100).(0.1)
       0.9996401052677814
-      
+
   """
   @spec cdf(number, number) :: fun
   def cdf(a, b) do
@@ -53,7 +48,7 @@ defmodule Statistics.Distributions.Beta do
 
       iex> Statistics.Distributions.Beta.ppf(1,100).(0.1)
       0.001053089271799999
-      
+
   """
   @spec ppf(number, number) :: fun
   def ppf(a, b) do

--- a/lib/statistics/distributions/binomial.ex
+++ b/lib/statistics/distributions/binomial.ex
@@ -5,7 +5,7 @@ defmodule Statistics.Distributions.Binomial do
   Binomial distribution.
 
   This models the expected outcome of a number
-  of binary trials, each with known probability, 
+  of binary trials, each with known probability,
   (often called a Bernoulli trial)
   """
 
@@ -20,18 +20,17 @@ defmodule Statistics.Distributions.Binomial do
   """
   @spec pmf(non_neg_integer, number) :: fun
   def pmf(n, p) do
-    fn k ->
-      cond do
-        k < 1.0 ->
-          0.0
+    fn
+      k when k < 1.0 ->
+        0.0
 
-        n < k ->
+      k ->
+        if n < k do
           0.0
-
-        true ->
+        else
           xk = Math.to_int(k)
           Math.combination(n, xk) * Math.pow(p, xk) * Math.pow(1 - p, n - xk)
-      end
+        end
     end
   end
 

--- a/lib/statistics/distributions/exponential.ex
+++ b/lib/statistics/distributions/exponential.ex
@@ -23,17 +23,12 @@ defmodule Statistics.Distributions.Exponential do
   end
 
   def pdf(lambda) do
-    fn x ->
-      cond do
-        x < 0 ->
-          0
+    fn
+      x < 0 ->
+        0
 
-        lambda <= 0 ->
-          :nan
-
-        true ->
-          lambda * Math.exp(-lambda * x)
-      end
+      x ->
+        if lambda <= 0, do: :nan, else: lambda * Math.exp(-lambda * x)
     end
   end
 
@@ -53,17 +48,12 @@ defmodule Statistics.Distributions.Exponential do
   end
 
   def cdf(lambda) do
-    fn x ->
-      cond do
-        x < 0 ->
-          0
+    fn
+      x < 0 ->
+        0
 
-        lambda <= 0 ->
-          :nan
-
-        true ->
-          1 - Math.exp(-lambda * x)
-      end
+      x ->
+        if lambda <= 0, do: :nan, else: 1 - Math.exp(-lambda * x)
     end
   end
 
@@ -83,17 +73,16 @@ defmodule Statistics.Distributions.Exponential do
   end
 
   def ppf(lambda) do
-    fn x ->
-      cond do
-        x == 1 ->
-          :inf
+    fn
+      x == 1 ->
+        :inf
 
-        x < 0 or x > 1 or lambda < 0 ->
+      x ->
+        if x < 0 or x > 1 or lambda < 0 do
           :nan
-
-        true ->
-          -1 * Math.ln(1 - x) / lambda
-      end
+        else
+          -1 * Match.ln(1 - x) / lambda
+        end
     end
   end
 

--- a/lib/statistics/distributions/f.ex
+++ b/lib/statistics/distributions/f.ex
@@ -40,12 +40,12 @@ defmodule Statistics.Distributions.F do
 
       iex> Statistics.Distributions.F.cdf(1,1).(1)
       0.4971668763845647
-      
+
   NOTE this is rather imprecise owing to the use
-  of numerical integration of `Beta.pdf/2` to 
+  of numerical integration of `Beta.pdf/2` to
   approximate the regularised incomplete beta function
   """
-  # NOTE the cdf is defined in terms of 
+  # NOTE the cdf is defined in terms of
   # the regularised incomplete Beta function
   # which is the CDF of the Beta distribution
   @spec cdf(number, number) :: fun
@@ -65,7 +65,7 @@ defmodule Statistics.Distributions.F do
 
       iex> Statistics.Distributions.F.ppf(1,1).(1)
       1.0180414899099999
-      
+
   """
   @spec ppf(number, number) :: fun
   def ppf(d1, d2) do
@@ -98,7 +98,7 @@ defmodule Statistics.Distributions.F do
   end
 
   @doc """
-  Draw a random number from an F distribution 
+  Draw a random number from an F distribution
   """
   @spec rand(number, number) :: number
   def rand(d1, d2) do

--- a/lib/statistics/distributions/normal.ex
+++ b/lib/statistics/distributions/normal.ex
@@ -2,7 +2,7 @@ defmodule Statistics.Distributions.Normal do
   @moduledoc """
   The normal, or gaussian, distribution
 
-  When invoking the distibution functions without parameters, 
+  When invoking the distibution functions without parameters,
   a distribution with mean of 0 and standard deviation of 1 is assumed.
   """
 
@@ -89,18 +89,11 @@ defmodule Statistics.Distributions.Normal do
 
   @spec ppf(number, number) :: fun
   def ppf(mu, sigma) do
-    res = fn p ->
-      mu + p * sigma
-    end
+    res = &(mu + &1 * sigma)
 
-    fn x ->
-      cond do
-        x < 0.5 ->
-          res.(-Functions.inv_erf(Math.sqrt(-2.0 * Math.ln(x))))
-
-        x >= 0.5 ->
-          res.(Functions.inv_erf(Math.sqrt(-2.0 * Math.ln(1 - x))))
-      end
+    fn
+      x < 0.5 -> res.(-Functions.inv_erf(Math.sqrt(-2.0 * Math.ln(x))))
+      x >= 0.5 -> res.(Functions.inv_erf(Math.sqrt(-2.0 * Math.ln(1 - x))))
     end
   end
 
@@ -140,14 +133,12 @@ defmodule Statistics.Distributions.Normal do
     # too small to calculate with the precision available to us)
     x = Math.rand() * 20 - 10
 
-    cond do
-      rpdf.(x) > Math.rand() ->
-        # transpose to specified distribution
-        mu - x * sigma
-
-      true ->
-        # keep trying
-        rand(mu, sigma, rpdf)
+    if rpdf.(x) > Math.rand() do
+      # transpose to specified distribution
+      mu - x * sigma
+    else
+      # keep trying
+      rand(mu, sigma, rpdf)
     end
   end
 end

--- a/lib/statistics/distributions/poisson.ex
+++ b/lib/statistics/distributions/poisson.ex
@@ -43,7 +43,8 @@ defmodule Statistics.Distributions.Poisson do
 
     fn k ->
       s =
-        Enum.map(0..Math.to_int(k), fn x -> Math.pow(lambda, x) / Math.factorial(x) end)
+        0..Math.to_int(k)
+        |> Enum.map(fn x -> Math.pow(lambda, x) / Math.factorial(x) end)
         |> Enum.sum()
 
       nexp * s
@@ -66,10 +67,7 @@ defmodule Statistics.Distributions.Poisson do
   @spec ppf(number) :: fun
   def ppf(lambda) do
     lcdf = cdf(lambda)
-
-    fn x ->
-      ppf_tande(x, lcdf, 0.0)
-    end
+    &ppf_tande(&1, lcdf, 0.0)
   end
 
   # the trusty trial-and-error method


### PR DESCRIPTION
All this does is move some run-time comparisons down to compile-time so that when there is a guard checking for `x <= 0.0` or something, it happens faster and the real work can happen sooner.