### PR TITLE
Correct @spec for Statistics.mean

### DIFF
--- a/lib/statistics.ex
+++ b/lib/statistics.ex
@@ -27,7 +27,7 @@ defmodule Statistics do
       2.0
 
   """
-  @spec mean(list) :: number
+  @spec mean(list(number)) :: float() | nil
   def mean(list) when is_list(list), do: do_mean(list, 0, 0)
 
   defp do_mean([], 0, 0), do: nil


### PR DESCRIPTION
From `do_mean` you can see that `nil` is the outcome for calls to `Statistics.mean([])`. The missing `nil` means that dialyzer won't allow you to pattern match on `nil`/`float` in the result.